### PR TITLE
adds publication claiming functionality

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,14 +9,32 @@ class ApplicationController < ActionController::Base
   # the application to behave in a sane way regardless of which authentication method
   # is used to log the user in.
   devise_group :user, contains: [:user, :cas_user]
-  before_action :authenticate_or_redirect_user!
+  before_action :store_location!, if: :storable_location?
+  before_action :authenticate_user!, except: [:sessions, :cas_sessions, :registrations, :passwords]
 
   private
-  def authenticate_or_redirect_user!
-    if user_signed_in? || %w(sessions cas_sessions registrations passwords).include?(controller_name)
-      authenticate_user!
-    else
-      redirect_to new_user_session_path
-    end
+
+  ##
+  # Override Devise method to manually set the key to :user since
+  # this application make use of a devise_group containing multiple models
+  def stored_location_for(resource)
+    session_key = stored_location_key_for(:user)
+    return session.delete(session_key) if is_navigational_format?
+    session[session_key]
+  end
+
+  # Its important that the location is NOT stored if:
+  # - The request method is not GET (non idempotent)
+  # - The request is handled by a Devise controller such as Devise::SessionsController as that could cause an
+  #    infinite redirect loop.
+  # - The request is an Ajax request as this can lead to very unexpected behaviour.
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+  end
+
+  ##
+  # Store the location for redirection after successful authentication
+  def store_location!
+    store_location_for(:user, request.fullpath)
   end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -1,7 +1,8 @@
 require 'csv'
 
 class PublicationsController < ApplicationController
-  before_action :get_record, except: [:index, :harvest]
+  before_action :get_record, except: [:index, :harvest, :claim]
+  before_action :get_record_by_hashed_uid, only: :claim
 
   def harvest
     institution = ["Oregon State University", "Oregon State Univ"]
@@ -69,7 +70,20 @@ class PublicationsController < ApplicationController
     end
   end
 
+  def claim
+    current_user.publications << @publication
+    respond_to do |format|
+      format.html { redirect_to edit_publication_path(@publication), notice: "You've claimed this publication, please update and publish it." }
+      format.json { head :no_content }
+    end
+  end
+
   private
+
+  def get_record_by_hashed_uid
+    @wos_record = WebOfScienceSourceRecord.includes(:publication).where(hashed_uid: params[:hashed_uid]).first
+    @publication = @wos_record.publication
+  end
 
   def get_record
     id = params[:id] || params[:publication_id]

--- a/app/models/cas_user.rb
+++ b/app/models/cas_user.rb
@@ -1,5 +1,7 @@
 class CasUser < ActiveRecord::Base
   has_many :jobs, inverse_of: :cas_user
+  has_and_belongs_to_many :publications
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :cas_authenticatable

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -6,6 +6,8 @@ class Publication < ActiveRecord::Base
   has_one :web_of_science_source_record, autosave: true, dependent: :destroy
   has_many_attached :publication_files
   has_many :jobs, inverse_of: :publication, dependent: :destroy
+  has_and_belongs_to_many :users
+  has_and_belongs_to_many :cas_users
 
   serialize :pub_hash, Hash
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ActiveRecord::Base
   has_many :jobs, inverse_of: :user
+  has_and_belongs_to_many :publications
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/web_of_science_source_record.rb
+++ b/app/models/web_of_science_source_record.rb
@@ -36,6 +36,9 @@ class WebOfScienceSourceRecord < ActiveRecord::Base
       self.source_data = @record.to_xml
     end
     self.source_fingerprint ||= Digest::SHA2.hexdigest(source_data)
+    # Intended to be used as part of the Email invitation to an author to claim the publication
+    # related to this WSSR
+    self.hashed_uid ||= Digest::SHA2.hexdigest(record.uid)
     self.database ||= record.database
     self.uid ||= record.uid
     self.doi ||= record.doi if record.doi.present?

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -5,16 +5,15 @@
     %span.navbar-toggler-icon
   <!-- Collect the nav links, forms, and other content for toggling -->
   .collapse.navbar-collapse#bs-example-navbar-collapse-1
-    %ul.nav.navbar-nav.ml-auto
-      %li.nav-item.welcome
-        - if user_signed_in?
+    - if user_signed_in?
+      %ul.nav.navbar-nav.ml-auto
+        %li.nav-item.welcome
           %p
             Logged in as
             = current_user.username
-      %li.nav-item.link= link_to 'Publications', publications_path, class: 'nav-link'
-      - if user_signed_in? && current_user.admin?
-        %li.nav-item= link_to 'Admin', rails_admin_path, class: 'nav-link faded'
-      - if user_signed_in?
+        %li.nav-item.link= link_to 'Publications', publications_path, class: 'nav-link'
+        - if current_user.admin?
+          %li.nav-item= link_to 'Admin', rails_admin_path, class: 'nav-link faded'
         %li.nav-item= link_to 'Logout', destroy_user_session_path, method: :delete, class: 'nav-link faded'
   #sub_nav
     %h1 Easy Deposit @ Oregon State University Libraries and Press

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   devise_for :users
   devise_for :cas_users
 
+  get '/claim/:hashed_uid', to: 'publications#claim', as: 'claim'
+
   ##
   # Endpoint for Pub harvester
   get '/publications/harvest', to: 'publications#harvest', defaults: { format: :json }

--- a/db/migrate/20180709213947_create_join_table_user_publication.rb
+++ b/db/migrate/20180709213947_create_join_table_user_publication.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableUserPublication < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :users, :publications do |t|
+      # t.index [:user_id, :publication_id]
+      # t.index [:publication_id, :user_id]
+    end
+  end
+end

--- a/db/migrate/20180709214046_create_join_table_cas_user_publication.rb
+++ b/db/migrate/20180709214046_create_join_table_cas_user_publication.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableCasUserPublication < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :cas_users, :publications do |t|
+      # t.index [:cas_user_id, :publication_id]
+      # t.index [:publication_id, :cas_user_id]
+    end
+  end
+end

--- a/db/migrate/20180709223435_add_hashed_uid_to_web_of_science_source_record.rb
+++ b/db/migrate/20180709223435_add_hashed_uid_to_web_of_science_source_record.rb
@@ -1,0 +1,5 @@
+class AddHashedUidToWebOfScienceSourceRecord < ActiveRecord::Migration[5.2]
+  def change
+    add_column :web_of_science_source_records, :hashed_uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_08_232636) do
+ActiveRecord::Schema.define(version: 2018_07_09_223435) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name", null: false
@@ -54,6 +54,11 @@ ActiveRecord::Schema.define(version: 2018_07_08_232636) do
     t.index ["username"], name: "index_cas_users_on_username", unique: true
   end
 
+  create_table "cas_users_publications", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.bigint "cas_user_id", null: false
+    t.bigint "publication_id", null: false
+  end
+
   create_table "jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.bigint "publication_id"
     t.string "name"
@@ -79,6 +84,11 @@ ActiveRecord::Schema.define(version: 2018_07_08_232636) do
     t.text "xml"
     t.text "pub_hash"
     t.datetime "pub_at"
+  end
+
+  create_table "publications_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "publication_id", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
@@ -122,6 +132,7 @@ ActiveRecord::Schema.define(version: 2018_07_08_232636) do
     t.string "doi"
     t.string "pmid"
     t.bigint "publication_id"
+    t.string "hashed_uid"
     t.index ["publication_id"], name: "index_web_of_science_source_records_on_publication_id"
   end
 


### PR DESCRIPTION
Provides the functionality necessary for handling links that will be delivered to authors to claim a publication. 

`claim_path(hashed_uid: @wos_record.hashed_uid)` : Generates the appropriate link path.
