### PR TITLE
fixes timing bug with author email fetching

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -75,7 +75,7 @@ class PublicationsController < ApplicationController
   end
 
   def claim
-    current_user.publications << @publication
+    current_user.publications << @publication unless current_user.publications.include?(@publication)
     @publication.await_attachments! unless @publication.awaiting_attachments?
     flash[:warn] = t('publications.claim_message')
     respond_to do |format|

--- a/app/jobs/publish_work_job.rb
+++ b/app/jobs/publish_work_job.rb
@@ -131,7 +131,7 @@ class PublishWorkJob < ApplicationJob
     if response.nil?
       "#{repository_client.url}/concern/articles/#{id}"
     else
-      "#{repository_client.url}#{response.headers[:location]}"
+      "#{repository_client.url}#{response.headers[:location].split('?').first}"
     end
   end
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -133,6 +133,6 @@ class Publication < ActiveRecord::Base
   end
 
   def completed_fetching_authors?
-    events.where(name: [Event::FETCH_AUTHORS_DIRECTORY_API[:name], Event::FETCH_AUTHORS_EMAILS_WOS[:name]], status: Event::COMPLETED[:name]).count == 2
+    events.reload.where(name: [Event::FETCH_AUTHORS_DIRECTORY_API[:name], Event::FETCH_AUTHORS_EMAILS_WOS[:name]], status: Event::COMPLETED[:name]).count == 2
   end
 end


### PR DESCRIPTION
fixes #133 

Prevents a publication from being associated to the same user more than once.
Fixes the publication url to remove the `?locale=en`